### PR TITLE
Fixed returned beam vector, replaced deprecated bzero with memset

### DIFF
--- a/src/GTreeA2Geant.cc
+++ b/src/GTreeA2Geant.cc
@@ -142,8 +142,9 @@ GTreeA2Geant::~GTreeA2Geant()
 
 TLorentzVector GTreeA2Geant::GetBeam() const
 {
-    //                          x         y         z         E
-    return TLorentzVector(fbeam[0], fbeam[1], fbeam[2], fbeam[4]);
+    double x = fbeam[0], y = fbeam[1], z = fbeam[2], t = fbeam[3];
+
+    return TLorentzVector(t*x, t*y, t*z, t);
 }
 
 TVector3 GTreeA2Geant::GetVertex() const
@@ -437,7 +438,7 @@ TLorentzVector GTreeA2Geant::GetTrueVector(const UInt_t n) const throw(std::out_
 
 template <class T>
 void zero( T& data ) {
-    bzero( data, sizeof(data));
+    memset( data, 0, sizeof(data) );
 }
 
 void GTreeA2Geant::Clear()


### PR DESCRIPTION
The previously returned beam vector was wrong, replaced it with the correct one. Also replaced the deprecated and non-standard bzero() with memset().