### PR TITLE
Added methods to get specific 4 momenta directly

### DIFF
--- a/inc/GTreePluto.h
+++ b/inc/GTreePluto.h
@@ -3,7 +3,7 @@
 
 
 #include "GTree.h"
-
+#include "PParticle.h"
 #include "TClonesArray.h"
 
 #include <list>
@@ -28,6 +28,9 @@ public:
 
     virtual void                Clear()                 { PlutoMCTrue->Clear(); plutoID=-1; plutoRandomID=1; }
     virtual TClonesArray* 		GetMCTrue()        		{ return PlutoMCTrue; }
+    virtual PParticle*          GetMCTrue(const int idx) const;
+    virtual TLorentzVector      GetTrueP4(const int idx) const;
+    virtual TLorentzVector      GetTrueBeam() const;
     virtual Long64_t            GetPlutoID()       const     { return plutoID; }
     virtual Long64_t            GetPlutoRandomID() const     { return plutoRandomID; }
 

--- a/src/GTreePluto.cc
+++ b/src/GTreePluto.cc
@@ -42,6 +42,37 @@ GTreePluto::ParticleList GTreePluto::GetAllParticles() const
     return list;
 }
 
+PParticle* GTreePluto::GetMCTrue(const int idx) const
+{
+    if (!PlutoMCTrue) {
+        //return nullptr;
+        fprintf(stderr, "ERROR: No Pluto Tree in current file!\n");
+        exit(1);
+    }
+
+    return dynamic_cast<PParticle*>(PlutoMCTrue->At(idx));
+}
+
+TLorentzVector GTreePluto::GetTrueP4(const int idx) const
+{
+    if (!PlutoMCTrue) {
+        fprintf(stderr, "ERROR: No Pluto Tree in current file!\n");
+        exit(1);
+    }
+
+    return dynamic_cast<PParticle*>(PlutoMCTrue->At(idx))->Vect4();
+}
+
+// Assume proton target
+TLorentzVector GTreePluto::GetTrueBeam() const
+{
+    if (!PlutoMCTrue) {
+        fprintf(stderr, "ERROR: No Pluto Tree in current file!\n");
+        exit(1);
+    }
+
+    return dynamic_cast<PParticle*>(PlutoMCTrue->At(0))->Vect4() - TLorentzVector(0., 0., 0., .938272);
+}
 
 void    GTreePluto::SetBranchAdresses()
 {


### PR DESCRIPTION
Suggestion: Added new methods to access certain particle or vector information directly from the Pluto tree if it exists. Exit otherwise to avoid usage of wrong information / NULL pointers. Maybe overload GetTrueBeam() if other targets are used. 