### PR TITLE
ant fix CMakeLists for Ubuntu

### DIFF
--- a/ant/CMakeLists.txt
+++ b/ant/CMakeLists.txt
@@ -93,10 +93,10 @@ foreach(PROG_SRC ${ANT_PROGS})
         )
 
     target_link_libraries(${name}
-        antlib
-        ${LIBS}
-        ${ROOT_LIBRARIES}
+    	antlib
+    	${APLCON_LIBRARIES}
         goatlib
-        ${APLCON_LIBRARIES}
+        ${LIBS}
+    	${ROOT_LIBRARIES}
     )
 endforeach()


### PR DESCRIPTION
Ubuntu needs a certain order of libraries in the CMakeList (if A depends on B, A has to come before B). Oli helped me to fix this.